### PR TITLE
Flysystem 3 support

### DIFF
--- a/_config/assetadmin.yml
+++ b/_config/assetadmin.yml
@@ -8,3 +8,8 @@ SilverStripe\AssetAdmin\Model\ThumbnailGenerator:
   thumbnail_links:
     protected: url
     public: url
+
+# Asset-admin adds a `vid` parameter to preview URLs by default.
+# This confuses the Google Cloud signature for protected assets, so we disable it.
+SilverStripe\AssetAdmin\Controller\AssetAdmin:
+  bust_cache: false

--- a/_config/assets.yml
+++ b/_config/assets.yml
@@ -13,55 +13,87 @@ SilverStripe\Core\Injector\Injector:
       bucket: '`GC_BUCKET_NAME`'
       keyFile: '`GC_KEY_FILE`'
 
-  League\Flysystem\Adapter\Local:
-    class: League\Flysystem\Adapter\Local
-    constructor:
-      root: '`TEMP_PATH`'
-
   SilverStripe\GoogleCloudStorage\Adapter\PublicAdapter:
     constructor:
       bucketAdapter: '%$SilverStripe\GoogleCloudStorage\Adapter\BucketAdapter'
       prefix: '`GC_PUBLIC_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Memory.public:
-    class: League\Flysystem\Cached\Storage\Memory
-  League\Flysystem\Cached\Storage\Adapter.public:
-    class: League\Flysystem\Cached\Storage\Adapter
+  Symfony\Component\Cache\Adapter\FilesystemAdapter.public:
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
     constructor:
-      adapter: '%$League\Flysystem\Adapter\Local'
-      file: 'gcmetadata/public'
-      expire: 259200
+      namespace: 'flysystem-public'
+      expire: 2592000
   SilverStripe\Assets\Flysystem\PublicAdapter:
     class: SilverStripe\GoogleCloudStorage\Adapter\PublicCachedAdapter
     constructor:
       adapter: '%$SilverStripe\GoogleCloudStorage\Adapter\PublicAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Adapter.public'
+      cache: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter.public'
+  League\Flysystem\Filesystem.public:
+    class: SilverStripe\Assets\Flysystem\Filesystem
+    constructor:
+      FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\PublicAdapter'
+      FilesystemConfig:
+        visibility: public
 
   SilverStripe\GoogleCloudStorage\Adapter\ProtectedAdapter:
     constructor:
       bucketAdapter: '%$SilverStripe\GoogleCloudStorage\Adapter\BucketAdapter'
       prefix: '`GC_PROTECTED_BUCKET_PREFIX`'
-  League\Flysystem\Cached\Storage\Adapter.protected:
-      class: League\Flysystem\Cached\Storage\Adapter
-      constructor:
-        adapter: '%$League\Flysystem\Adapter\Local'
-        file: 'gcmetadata/protected'
-        expire: 259200
+  Symfony\Component\Cache\Adapter\FilesystemAdapter.protected:
+    class: Symfony\Component\Cache\Adapter\FilesystemAdapter
+    constructor:
+      namespace: 'flysystem-protected'
+      expire: 2592000
   SilverStripe\Assets\Flysystem\ProtectedAdapter:
     class: SilverStripe\GoogleCloudStorage\Adapter\ProtectedCachedAdapter
     constructor:
       adapter: '%$SilverStripe\GoogleCloudStorage\Adapter\ProtectedAdapter'
-      cache: '%$League\Flysystem\Cached\Storage\Adapter.protected'
-#---
+      cache: '%$Symfony\Component\Cache\Adapter\FilesystemAdapter.protected'
+  League\Flysystem\Filesystem.protected:
+    class: SilverStripe\Assets\Flysystem\Filesystem
+    constructor:
+      FilesystemAdapter: '%$SilverStripe\Assets\Flysystem\ProtectedAdapter'
+      FilesystemConfig:
+        visibility: private
+---
 Name: silverstripegooglecloudstorage-assetscore
 Only:
   envvarset: GC_BUCKET_NAME
 After:
+  - '#assetsflysystem'
   - '#assetscore'
 ---
 SilverStripe\Core\Injector\Injector:
   # Define our SS asset backend
   SilverStripe\Assets\Storage\AssetStore:
     class: SilverStripe\Assets\Flysystem\FlysystemAssetStore
+    properties:
+      PublicFilesystem: '%$League\Flysystem\Filesystem.public'
+      ProtectedFilesystem: '%$League\Flysystem\Filesystem.protected'
+  SilverStripe\Assets\Storage\GeneratedAssetHandler:
+    class: SilverStripe\Assets\Flysystem\GeneratedAssets
+    properties:
+      Filesystem: '%$League\Flysystem\Filesystem.public'
+  SilverStripe\View\Requirements_Backend:
+    properties:
+      AssetHandler: '%$SilverStripe\Assets\Storage\GeneratedAssetHandler'
+
+---
+Name: silverstripegooglecloudstorage-cdn
+Only:
+  envvarset: GC_PUBLIC_CDN_PREFIX
+After:
+  - '#assetsflysystem'
+  - '#silverstripegooglecloudstorage-flysystem'
+---
+SilverStripe\Core\Injector\Injector:
+  SilverStripe\GoogleCloudStorage\Adapter\PublicAdapter:
+    class: SilverStripe\GoogleCloudStorage\Adapter\PublicCDNAdapter
+    constructor:
+      bucketAdapter: '%$SilverStripe\GoogleCloudStorage\Adapter\BucketAdapter'
+      prefix: '`GC_PUBLIC_BUCKET_PREFIX`'
+      cdnPrefix: '`GC_PUBLIC_CDN_PREFIX`'
+
+---
 Name: silverstripegooglecloudstorage-errorpage
 Only:
   envvarset: GC_BUCKET_NAME
@@ -70,4 +102,4 @@ After:
 ---
 SilverStripe\ErrorPage\ErrorPage:
   store_filepath: 'error-pages'
-#---
+---

--- a/_config/tinymce.yml
+++ b/_config/tinymce.yml
@@ -1,10 +1,11 @@
 ---
+Name: silverstripegooglecloudstorage-tinymce
 After:
   - '#corehtml'
 ---
 SilverStripe\Core\Injector\Injector:
   League\Flysystem\Filesystem.localpublic:
-    class: 'League\Flysystem\Filesystem'
+    class: 'SilverStripe\Assets\Flysystem\Filesystem'
     constructor:
       FilesystemAdapter: '%$SilverStripe\GoogleCloudStorage\Adapter\TinyMceAdapter'
       FilesystemConfig:

--- a/composer.json
+++ b/composer.json
@@ -6,9 +6,9 @@
     "authors": [],
     "require": {
         "silverstripe/framework": "^5",
-        "silverstripe/vendor-plugin": "^1 || ^2",
+        "silverstripe/vendor-plugin": "^2",
         "league/flysystem-google-cloud-storage": "^3.16.0",
-        "jgivoni/flysystem-cache-adapter": "^3.0.1"
+        "jgivoni/flysystem-cache-adapter": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4.3",
-        "silverstripe/vendor-plugin": "^1.0",
+        "silverstripe/framework": "^4 || ^5",
+        "silverstripe/vendor-plugin": "^1 || ^2",
         "silverstripe/assets": "^1.3",
         "superbalist/flysystem-google-storage": "^7.1",
         "league/flysystem-cached-adapter": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -4,17 +4,11 @@
     "type": "silverstripe-vendormodule",
     "license": "MIT",
     "authors": [],
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "git@github.com:wedevelopnl/flysystem-cache-adapter.git"
-        }
-    ],
     "require": {
         "silverstripe/framework": "^5",
         "silverstripe/vendor-plugin": "^2",
         "league/flysystem-google-cloud-storage": "^3.16.0",
-        "jgivoni/flysystem-cache-adapter": "dev-bugfix/remove-array-caching"
+        "jgivoni/flysystem-cache-adapter": "^3.0.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,12 @@
     "description": "SilverStripe module to store assets in Google Cloud Storage rather than on the local filesystem.",
     "type": "silverstripe-vendormodule",
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Joe Madden",
-            "email": "obj63mc@gmail.com"
-        }
-    ],
+    "authors": [],
     "require": {
-        "silverstripe/framework": "^4 || ^5",
+        "silverstripe/framework": "^5",
         "silverstripe/vendor-plugin": "^1 || ^2",
-        "superbalist/flysystem-google-storage": "^7.1",
-        "league/flysystem-cached-adapter": "^1.0"
+        "league/flysystem-google-cloud-storage": "^3.16.0",
+        "jgivoni/flysystem-cache-adapter": "^3.0.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -4,11 +4,17 @@
     "type": "silverstripe-vendormodule",
     "license": "MIT",
     "authors": [],
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "git@github.com:wedevelopnl/flysystem-cache-adapter.git"
+        }
+    ],
     "require": {
         "silverstripe/framework": "^5",
         "silverstripe/vendor-plugin": "^2",
         "league/flysystem-google-cloud-storage": "^3.16.0",
-        "jgivoni/flysystem-cache-adapter": "^3.0"
+        "jgivoni/flysystem-cache-adapter": "dev-bugfix/remove-array-caching"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     "require": {
         "silverstripe/framework": "^4 || ^5",
         "silverstripe/vendor-plugin": "^1 || ^2",
-        "silverstripe/assets": "^1.3",
         "superbalist/flysystem-google-storage": "^7.1",
         "league/flysystem-cached-adapter": "^1.0"
     },

--- a/src/Adapter/BucketAdapter.php
+++ b/src/Adapter/BucketAdapter.php
@@ -9,7 +9,7 @@ class BucketAdapter {
     protected $client;
     public function __construct($bucketname, $keyFile){
         $this->client = new StorageClient([
-            'keyFile'=> json_decode($keyFile, true)
+            'keyFile'=> json_decode($keyFile, true),
         ]);
 
 

--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -2,27 +2,22 @@
 
 namespace SilverStripe\GoogleCloudStorage\Adapter;
 
-use Google\Cloud\Storage\StorageClient;
-use InvalidArgumentException;
-use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
+use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverstripeProtectedAdapter;
 
-/**
- * An adapter that allows the use of Google Cloud Storage to store and transmit assets rather than storing them locally.
- */
-class ProtectedAdapter extends GoogleStorageAdapter implements SilverstripeProtectedAdapter
+class ProtectedAdapter extends GoogleCloudStorageAdapter implements SilverstripeProtectedAdapter
 {
+    private BucketAdapter $bucketAdapter;
 
-
-    public function __construct(BucketAdapter $bucketAdapter, $prefix = null, $storageApiUri = null)
+    public function __construct(BucketAdapter $bucketAdapter, string $prefix = null)
     {
-        if (!$bucketAdapter) {
-            throw new InvalidArgumentException("GC_BUCKET_NAME environment variable not set");
-        }
         if (!$prefix) {
             $prefix = 'protected';
         }
-        parent::__construct($bucketAdapter->getClient(), $bucketAdapter->getBucket(), $prefix, $storageApiUri);
+
+        $this->bucketAdapter = $bucketAdapter;
+
+        parent::__construct($bucketAdapter->getBucket(), $prefix);
     }
 
 
@@ -31,17 +26,15 @@ class ProtectedAdapter extends GoogleStorageAdapter implements SilverstripeProte
      *
      * @return string
      */
-    public function getProtectedUrl($path)
+    public function getProtectedUrl($path): string
     {
-        $object = $this->getObject($path);
-        $signedUrl = $object->signedUrl(date_create('+1 day'), []);
-        if ($this->getStorageApiUri() !== self::STORAGE_API_URI_DEFAULT) {
-            if (!isset($options['cname'])) {
-                list($url, $params) = explode('?', $signedUrl, 2);
-                $signedUrl = $this->getUrl($path) . '?' . $params;
-            }
-        }
+        $object = $this->bucketAdapter->getBucket()->object($path);
+        return $object->signedUrl(date_create('+1 day'));
+    }
 
-        return $signedUrl;
+    public function getVisibility($path)
+    {
+        // Save an API call
+        return ['path' => $path, 'visibility' => self::VISIBILITY_PRIVATE];
     }
 }

--- a/src/Adapter/ProtectedAdapter.php
+++ b/src/Adapter/ProtectedAdapter.php
@@ -2,20 +2,17 @@
 
 namespace SilverStripe\GoogleCloudStorage\Adapter;
 
+use League\Flysystem\Config;
 use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter as SilverstripeProtectedAdapter;
 
 class ProtectedAdapter extends GoogleCloudStorageAdapter implements SilverstripeProtectedAdapter
 {
-    private BucketAdapter $bucketAdapter;
-
     public function __construct(BucketAdapter $bucketAdapter, string $prefix = null)
     {
         if (!$prefix) {
             $prefix = 'protected';
         }
-
-        $this->bucketAdapter = $bucketAdapter;
 
         parent::__construct($bucketAdapter->getBucket(), $prefix);
     }
@@ -28,13 +25,6 @@ class ProtectedAdapter extends GoogleCloudStorageAdapter implements Silverstripe
      */
     public function getProtectedUrl($path): string
     {
-        $object = $this->bucketAdapter->getBucket()->object($path);
-        return $object->signedUrl(date_create('+1 day'));
-    }
-
-    public function getVisibility($path)
-    {
-        // Save an API call
-        return ['path' => $path, 'visibility' => self::VISIBILITY_PRIVATE];
+        return $this->temporaryUrl($path, new \DateTime('+1 day'), new Config());
     }
 }

--- a/src/Adapter/ProtectedCachedAdapter.php
+++ b/src/Adapter/ProtectedCachedAdapter.php
@@ -2,13 +2,13 @@
 
 namespace SilverStripe\GoogleCloudStorage\Adapter;
 
-use League\Flysystem\Cached\CachedAdapter;
+use jgivoni\Flysystem\Cache\CacheAdapter;
 use SilverStripe\Assets\Flysystem\ProtectedAdapter;
 
-class ProtectedCachedAdapter extends CachedAdapter implements ProtectedAdapter
+class ProtectedCachedAdapter extends CacheAdapter implements ProtectedAdapter
 {
     public function getProtectedUrl($path)
     {
-        return $this->getAdapter()->getProtectedUrl($path);
+        return $this->adapter->getProtectedUrl($path);
     }
 }

--- a/src/Adapter/PublicAdapter.php
+++ b/src/Adapter/PublicAdapter.php
@@ -2,31 +2,23 @@
 
 namespace SilverStripe\GoogleCloudStorage\Adapter;
 
-use Google\Cloud\Storage\StorageClient;
-use InvalidArgumentException;
-use Superbalist\Flysystem\GoogleStorage\GoogleStorageAdapter;
+use League\Flysystem\Config;
+use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
 use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
 
-class PublicAdapter extends GoogleStorageAdapter implements SilverstripePublicAdapter
+class PublicAdapter extends GoogleCloudStorageAdapter implements SilverstripePublicAdapter
 {
-    public function __construct(BucketAdapter $bucketAdapter, $prefix = null, $storageApiUri = null)
+    public function __construct(BucketAdapter $bucketAdapter, string $prefix = null)
     {
-        if (!$bucketAdapter) {
-            throw new InvalidArgumentException("GC_BUCKET_NAME environment variable not set");
-        }
         if (!$prefix) {
             $prefix = 'public';
         }
-        parent::__construct($bucketAdapter->getClient(), $bucketAdapter->getBucket(), $prefix, $storageApiUri);
+
+        parent::__construct($bucketAdapter->getBucket(), $prefix);
     }
 
-    /**
-     * @param string $path
-     *
-     * @return string
-     */
-    public function getPublicUrl($path)
+    public function getPublicUrl($path): string
     {
-        return $this->getUrl($path);
+        return $this->publicUrl($path, new Config());
     }
 }

--- a/src/Adapter/PublicCDNAdapter.php
+++ b/src/Adapter/PublicCDNAdapter.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SilverStripe\GoogleCloudStorage\Adapter;
+
+use SilverStripe\Assets\Flysystem\PublicAdapter as SilverstripePublicAdapter;
+use SilverStripe\Control\Controller;
+
+/**
+ * Class PublicCDNAdapter
+ * @package SilverStripe\S3\Adapter
+ */
+class PublicCDNAdapter extends PublicAdapter implements SilverstripePublicAdapter
+{
+    protected ?string $cdnPrefix;
+
+    public function __construct(BucketAdapter $bucketAdapter, string $prefix = null, string $cdnPrefix = null)
+    {
+        $this->cdnPrefix = $cdnPrefix;
+        parent::__construct($bucketAdapter, $prefix);
+    }
+
+    public function getPublicUrl($path): string
+    {
+        return Controller::join_links($this->cdnPrefix, $path);
+    }
+}

--- a/src/Adapter/PublicCachedAdapter.php
+++ b/src/Adapter/PublicCachedAdapter.php
@@ -2,13 +2,13 @@
 
 namespace SilverStripe\GoogleCloudStorage\Adapter;
 
-use League\Flysystem\Cached\CachedAdapter;
+use jgivoni\Flysystem\Cache\CacheAdapter;
 use SilverStripe\Assets\Flysystem\PublicAdapter;
 
-class PublicCachedAdapter extends CachedAdapter implements PublicAdapter
+class PublicCachedAdapter extends CacheAdapter implements PublicAdapter
 {
     public function getPublicUrl($path)
     {
-        return $this->getAdapter()->getPublicUrl($path);
+        return $this->adapter->getPublicUrl($path);
     }
 }


### PR DESCRIPTION
As promised here is a PR with all the changes needed to support Flysystem 3.
We're currently using this in production and it works well.

I haven't touched any of the documentation yet so this is most definitely out-of-date.

We are currently running this with Redis as persistent cache:

```yaml
---
Only:
  envvarset: REDIS_HOST
After:
  - 'silverstripegooglecloudstorage-flysystem'
  - '#corecache'
---
SilverStripe\Core\Injector\Injector:
  RedisClient:
    factory: App\Caching\RedisClientFactory
    constructor:
      host: '`REDIS_HOST`'
      port: '`REDIS_PORT`'
      db: '`REDIS_DB`'
      auth: '`REDIS_AUTH`'

  RedisCacheFactory:
    class: App\Caching\RedisCacheFactory
    constructor:
      client: '%$RedisClient'

  Symfony\Component\Cache\Adapter\FilesystemAdapter.protected:
    factory: '%$RedisCacheFactory'
    constructor:
      key: 'gcmetadata-protected'
      expire: 259200

  Symfony\Component\Cache\Adapter\FilesystemAdapter.public:
    factory: '%$RedisCacheFactory'
    constructor:
      key: 'gcmetadata-public'
      expire: 259200
```

The RedisCacheFactory looks like this:

```php
<?php

declare(strict_types=1);

namespace App\Caching;

use Psr\Container\NotFoundExceptionInterface;
use Redis;
use SilverStripe\Core\Injector\Factory;
use SilverStripe\Core\Injector\Injector;
use Symfony\Component\Cache\Adapter\AdapterInterface;
use Symfony\Component\Cache\Adapter\ArrayAdapter;
use Symfony\Component\Cache\Adapter\ChainAdapter;
use Symfony\Component\Cache\Adapter\RedisAdapter;

class RedisCacheFactory implements Factory
{
    public function __construct(private readonly Redis $redis)
    {
    }

    /**
     * @param $service
     * @param array<string, mixed> $params
     * @return AdapterInterface
     * @throws NotFoundExceptionInterface
     */
    public function create($service, array $params = [])
    {
        $key = $params['key'];
        $expire = (int)$params['expire'];

        return new ChainAdapter([
            new ArrayAdapter(),
            Injector::inst()
                ->createWithArgs(
                    RedisAdapter::class,
                    [
                        $this->redis,
                        $key,
                        $expire,
                    ]
                ),
        ]);
    }
}

```

Here you can see we use the ChainAdapter to also do in-memory caching for even more speeeeeed.

Let me know what you think.

I also noticed another branch were similar changes were done for Flysystem 3 support, I probably should have opened a draft PR to make our efforts more visible to prevent doing twice the work. We had a project to launch so that's what I focused on :)